### PR TITLE
Allow to set filter kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ regarding the request:
 set_http_request(self, method: str, url: str, user_agent: str = '') -> 'AuditLogger'
 set_http_response(self, status_code: int, reason: str, headers: dict = None) -> 'AuditLogger'
 set_user(self, authenticated: bool, provider: str, email: str, roles: list = None, ip: str = '', realm: str = '') -> 'AuditLogger'
-set_filter(self, object_name: str, fields: str, terms: str) -> 'AuditLogger'
+set_filter(self, object_name: str, kwargs: dict) -> 'AuditLogger'
 set_results(self, results: list = None) -> 'AuditLogger'
 ```
 
@@ -122,7 +122,7 @@ This method will add the following details to the log:
 ```
 
 ### Filter 
-`AuditLogger().set_filter(self, object_name: str, fields: str, terms: str)` allows to provide
+`AuditLogger().set_filter(self, object_name: str, kwargs: dict)` allows to provide
 info on the requested type of object and the filters that have been used  (a user searches 
 for 'terms', which are matched on specific 'fields' of the 'object').
 
@@ -131,8 +131,10 @@ This method will add the following details to the log:
 ```json
 "filter": {
     "object": "Object name that is requested",
-    "fields": "Fields that are being filtered on, if applicable",
-    "terms": "Search terms, if applicable"
+    "kwargs": {
+        'fields': 'filter values',
+        'more_fields': 'more filter values'
+    }
 }
 ```
 

--- a/audit_log/logger.py
+++ b/audit_log/logger.py
@@ -81,11 +81,10 @@ class AuditLogger:
         }
         return self
 
-    def set_filter(self, object_name: str, fields: str, terms: str) -> 'AuditLogger':
+    def set_filter(self, object_name: str, kwargs: dict) -> 'AuditLogger':
         self.filter = {
             'object': object_name,
-            'fields': fields,
-            'terms': terms
+            'kwargs': kwargs,
         }
         return self
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -79,10 +79,9 @@ class TestAuditlogger(TestCase):
 
     def test_set_filter(self):
         audit_log = AuditLogger()
-        audit_log.set_filter(object_name='objname', fields='fields', terms='terms')
+        audit_log.set_filter(object_name='objname', kwargs={'field': 'filter'})
         self.assertEqual(audit_log.filter['object'], 'objname')
-        self.assertEqual(audit_log.filter['fields'], 'fields')
-        self.assertEqual(audit_log.filter['terms'], 'terms')
+        self.assertEqual(audit_log.filter['kwargs'], {'field': 'filter'})
 
     def test_set_results(self):
         audit_log = AuditLogger()
@@ -134,13 +133,12 @@ class TestAuditlogger(TestCase):
 
     def test_extras_filter(self):
         audit_log = AuditLogger()
-        audit_log.set_filter(object_name='objname', fields='fields', terms='terms')
+        audit_log.set_filter(object_name='objname', kwargs={'field': 'filter'})
 
         extras = audit_log._get_extras(log_type='test')
         self.assertIn('filter', extras)
         self.assertEqual(extras['filter']['object'], 'objname')
-        self.assertEqual(extras['filter']['fields'], 'fields')
-        self.assertEqual(extras['filter']['terms'], 'terms')
+        self.assertEqual(extras['filter']['kwargs'], {'field': 'filter'})
 
     def test_extras_results(self):
         audit_log = AuditLogger()


### PR DESCRIPTION
Instead of having three fields model, fields and terms,
allow to set only model and kwargs. Kwargs is a dict
with model fields and the values that are being filtered on.