### PR TITLE
Feature/log initialization method

### DIFF
--- a/audit_log/logger.py
+++ b/audit_log/logger.py
@@ -5,19 +5,14 @@ from audit_log.formatter import AuditLogFormatter
 
 AUDIT_LOGGER_NAME = 'audit_log'
 
-logger = logging.getLogger(AUDIT_LOGGER_NAME)
-logger.setLevel(logging.INFO)
-logger.propagate = False
-
-handler = logging.StreamHandler(stream=sys.stdout)
-handler.setFormatter(AuditLogFormatter())
-logger.addHandler(handler)
-
 
 class AuditLogger:
 
     def __init__(self) -> None:
         super().__init__()
+
+        self.logger = self.init_logger()
+
         self.level = logging.INFO
         self.message = ''
         self.http_request = None
@@ -25,6 +20,26 @@ class AuditLogger:
         self.user = None
         self.filter = None
         self.results = None
+
+    def init_logger(self) -> logging.Logger:
+        logger = logging.getLogger(self.get_logger_name())
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+
+        handler = self.get_log_handler()
+        formatter = self.get_log_formatter()
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        return logger
+
+    def get_logger_name(self) -> str:
+        return AUDIT_LOGGER_NAME
+
+    def get_log_handler(self) -> logging.Handler:
+        return logging.StreamHandler(stream=sys.stdout)
+
+    def get_log_formatter(self) -> logging.Formatter:
+        return AuditLogFormatter()
 
     def debug(self, msg: str) -> 'AuditLogger':
         self.level = logging.DEBUG
@@ -93,7 +108,7 @@ class AuditLogger:
         return self
 
     def send_log(self) -> None:
-        logger.log(
+        self.logger.log(
             level=self.level,
             msg=self.message,
             extra={'audit': self._get_extras(logging.getLevelName(self.level))})
@@ -108,3 +123,4 @@ class AuditLogger:
             'type': log_type,
             'message': self.message
         }
+

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,90 +1,121 @@
 import logging
+import sys
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
+from audit_log.formatter import AuditLogFormatter
 from audit_log.logger import AuditLogger
 
 
 class TestAuditlogger(TestCase):
 
+    def setUp(self) -> None:
+        self.audit_log = AuditLogger()
+
+    def test_default_logger_name(self):
+        self.assertEqual(self.audit_log.get_logger_name(), 'audit_log')
+
+    def test_default_log_handler(self):
+        handler = self.audit_log.get_log_handler()
+        self.assertIsInstance(handler, logging.StreamHandler)
+        self.assertEqual(handler.stream, sys.stdout)
+
+    def test_default_log_formatter(self):
+        formatter = self.audit_log.get_log_formatter()
+        self.assertIsInstance(formatter, AuditLogFormatter)
+
+    @patch('audit_log.logger.AuditLogger.get_log_formatter')
+    @patch('audit_log.logger.AuditLogger.get_log_handler')
+    @patch('audit_log.logger.AuditLogger.get_logger_name')
+    def test_init_logger(self, mocked_get_logger_name, mocked_get_log_handler, mocked_get_log_formatter):
+        mocked_name = 'audit_logger_name'
+        mocked_handler = Mock()
+        mocked_formatter = Mock()
+        mocked_get_logger_name.return_value = mocked_name
+        mocked_get_log_handler.return_value = mocked_handler
+        mocked_get_log_formatter.return_value = mocked_formatter
+
+        # because we are mocking parts of the AuditLogger, we can not
+        # use the self.audit_logger created in setUp(), but we need to
+        # recreate it here!
+        logger = AuditLogger().init_logger()
+        self.assertEqual(logger.name, mocked_name)
+        self.assertEqual(logger.level, logging.INFO)
+        self.assertFalse(logger.propagate)
+
+        handlers = logger.handlers
+        self.assertEqual(len(handlers), 1)
+        handler = handlers[0]
+        self.assertEqual(handler, mocked_handler)
+        mocked_handler.setFormatter.assert_called_with(mocked_formatter)
+
     def test_default_log_level(self):
-        audit_log = AuditLogger()
-        self.assertEqual(audit_log.level, logging.INFO)
-        self.assertEqual(audit_log.message, '')
-        self.assertIsNone(audit_log.http_request)
-        self.assertIsNone(audit_log.http_response)
-        self.assertIsNone(audit_log.user)
-        self.assertIsNone(audit_log.filter)
-        self.assertIsNone(audit_log.results)
+        self.assertEqual(self.audit_log.level, logging.INFO)
+        self.assertEqual(self.audit_log.message, '')
+        self.assertIsNone(self.audit_log.http_request)
+        self.assertIsNone(self.audit_log.http_response)
+        self.assertIsNone(self.audit_log.user)
+        self.assertIsNone(self.audit_log.filter)
+        self.assertIsNone(self.audit_log.results)
 
     def test_debug(self):
-        audit_log = AuditLogger()
-        audit_log.debug('test')
-        self.assertEqual(audit_log.level, logging.DEBUG)
-        self.assertEqual(audit_log.message, 'test')
+        self.audit_log.debug('test')
+        self.assertEqual(self.audit_log.level, logging.DEBUG)
+        self.assertEqual(self.audit_log.message, 'test')
 
     def test_info(self):
-        audit_log = AuditLogger()
-        audit_log.info('test')
-        self.assertEqual(audit_log.level, logging.INFO)
-        self.assertEqual(audit_log.message, 'test')
+        self.audit_log.info('test')
+        self.assertEqual(self.audit_log.level, logging.INFO)
+        self.assertEqual(self.audit_log.message, 'test')
 
     def test_warning(self):
-        audit_log = AuditLogger()
-        audit_log.warning('test')
-        self.assertEqual(audit_log.level, logging.WARNING)
-        self.assertEqual(audit_log.message, 'test')
+        self.audit_log.warning('test')
+        self.assertEqual(self.audit_log.level, logging.WARNING)
+        self.assertEqual(self.audit_log.message, 'test')
 
     def test_error(self):
-        audit_log = AuditLogger()
-        audit_log.error('test')
-        self.assertEqual(audit_log.level, logging.ERROR)
-        self.assertEqual(audit_log.message, 'test')
+        self.audit_log.error('test')
+        self.assertEqual(self.audit_log.level, logging.ERROR)
+        self.assertEqual(self.audit_log.message, 'test')
 
     def test_critical(self):
-        audit_log = AuditLogger()
-        audit_log.critical('test')
-        self.assertEqual(audit_log.level, logging.CRITICAL)
-        self.assertEqual(audit_log.message, 'test')
+        self.audit_log.critical('test')
+        self.assertEqual(self.audit_log.level, logging.CRITICAL)
+        self.assertEqual(self.audit_log.message, 'test')
 
     def test_set_http_request(self):
-        audit_log = AuditLogger()
-        audit_log.set_http_request(method='GET', url='http://localhost/', user_agent='test_agent')
+        self.audit_log.set_http_request(method='GET', url='http://localhost/', user_agent='test_agent')
 
-        self.assertEqual(audit_log.http_request['method'], 'GET')
-        self.assertEqual(audit_log.http_request['url'], 'http://localhost/')
-        self.assertEqual(audit_log.http_request['user_agent'], 'test_agent')
+        self.assertEqual(self.audit_log.http_request['method'], 'GET')
+        self.assertEqual(self.audit_log.http_request['url'], 'http://localhost/')
+        self.assertEqual(self.audit_log.http_request['user_agent'], 'test_agent')
 
     def test_set_http_response(self):
-        audit_log = AuditLogger()
-        audit_log.set_http_response(status_code=200, reason='OK', headers={'Test': 'test'})
+        self.audit_log.set_http_response(status_code=200, reason='OK', headers={'Test': 'test'})
 
-        self.assertEqual(audit_log.http_response['status_code'], 200)
-        self.assertEqual(audit_log.http_response['reason'], 'OK')
-        self.assertEqual(audit_log.http_response['headers']['Test'], 'test')
+        self.assertEqual(self.audit_log.http_response['status_code'], 200)
+        self.assertEqual(self.audit_log.http_response['reason'], 'OK')
+        self.assertEqual(self.audit_log.http_response['headers']['Test'], 'test')
 
     def test_set_user(self):
-        audit_log = AuditLogger()
-        audit_log.set_user(
+        self.audit_log.set_user(
             authenticated=True, provider='test', email='username@host.com',
             roles=['role1', 'role2'], ip='12.23.34.45', realm='testrealm'
         )
 
-        self.assertEqual(audit_log.user['authenticated'], True)
-        self.assertEqual(audit_log.user['provider']['name'], 'test')
-        self.assertEqual(audit_log.user['provider']['realm'], 'testrealm')
-        self.assertEqual(audit_log.user['email'], 'username@host.com')
-        self.assertEqual(audit_log.user['roles'], ['role1', 'role2'])
-        self.assertEqual(audit_log.user['ip'], '12.23.34.45')
+        self.assertEqual(self.audit_log.user['authenticated'], True)
+        self.assertEqual(self.audit_log.user['provider']['name'], 'test')
+        self.assertEqual(self.audit_log.user['provider']['realm'], 'testrealm')
+        self.assertEqual(self.audit_log.user['email'], 'username@host.com')
+        self.assertEqual(self.audit_log.user['roles'], ['role1', 'role2'])
+        self.assertEqual(self.audit_log.user['ip'], '12.23.34.45')
 
     def test_set_filter(self):
-        audit_log = AuditLogger()
-        audit_log.set_filter(object_name='objname', kwargs={'field': 'filter'})
-        self.assertEqual(audit_log.filter['object'], 'objname')
-        self.assertEqual(audit_log.filter['kwargs'], {'field': 'filter'})
+        self.audit_log.set_filter(object_name='objname', kwargs={'field': 'filter'})
+        self.assertEqual(self.audit_log.filter['object'], 'objname')
+        self.assertEqual(self.audit_log.filter['kwargs'], {'field': 'filter'})
 
     def test_set_results(self):
-        audit_log = AuditLogger()
         test_results = [
             'There are the results',
             ['this', 'is', 'a', 'list'],
@@ -92,37 +123,34 @@ class TestAuditlogger(TestCase):
             123
         ]
         for results in test_results:
-            audit_log.set_results(results)
-            self.assertEqual(audit_log.results, results)
+            self.audit_log.set_results(results)
+            self.assertEqual(self.audit_log.results, results)
 
     def test_extras_http_request(self):
-        audit_log = AuditLogger()
-        audit_log.set_http_request(method='GET', url='http://localhost/', user_agent='test_agent')
+        self.audit_log.set_http_request(method='GET', url='http://localhost/', user_agent='test_agent')
 
-        extras = audit_log._get_extras(log_type='test')
+        extras = self.audit_log._get_extras(log_type='test')
         self.assertIn('http_request', extras)
         self.assertEqual(extras['http_request']['method'], 'GET')
         self.assertEqual(extras['http_request']['url'], 'http://localhost/')
         self.assertEqual(extras['http_request']['user_agent'], 'test_agent')
 
     def test_extras_http_response(self):
-        audit_log = AuditLogger()
-        audit_log.set_http_response(status_code=200, reason='OK', headers={'Test': 'test'})
+        self.audit_log.set_http_response(status_code=200, reason='OK', headers={'Test': 'test'})
 
-        extras = audit_log._get_extras(log_type='test')
+        extras = self.audit_log._get_extras(log_type='test')
         self.assertIn('http_response', extras)
         self.assertEqual(extras['http_response']['status_code'], 200)
         self.assertEqual(extras['http_response']['reason'], 'OK')
         self.assertEqual(extras['http_response']['headers']['Test'], 'test')
 
     def test_extras_user(self):
-        audit_log = AuditLogger()
-        audit_log.set_user(
+        self.audit_log.set_user(
             authenticated=True, provider='test', email='username@host.com',
             roles=['role1', 'role2'], ip='12.23.34.45', realm='testrealm'
         )
 
-        extras = audit_log._get_extras(log_type='test')
+        extras = self.audit_log._get_extras(log_type='test')
         self.assertIn('user', extras)
         self.assertEqual(extras['user']['authenticated'], True)
         self.assertEqual(extras['user']['provider']['name'], 'test')
@@ -132,16 +160,14 @@ class TestAuditlogger(TestCase):
         self.assertEqual(extras['user']['ip'], '12.23.34.45')
 
     def test_extras_filter(self):
-        audit_log = AuditLogger()
-        audit_log.set_filter(object_name='objname', kwargs={'field': 'filter'})
+        self.audit_log.set_filter(object_name='objname', kwargs={'field': 'filter'})
 
-        extras = audit_log._get_extras(log_type='test')
+        extras = self.audit_log._get_extras(log_type='test')
         self.assertIn('filter', extras)
         self.assertEqual(extras['filter']['object'], 'objname')
         self.assertEqual(extras['filter']['kwargs'], {'field': 'filter'})
 
     def test_extras_results(self):
-        audit_log = AuditLogger()
         test_results = [
             'There are the results',
             ['this', 'is', 'a', 'list'],
@@ -149,18 +175,24 @@ class TestAuditlogger(TestCase):
             123
         ]
         for results in test_results:
-            audit_log.set_results(results)
-            extras = audit_log._get_extras(log_type='test')
+            self.audit_log.set_results(results)
+            extras = self.audit_log._get_extras(log_type='test')
             self.assertIn('results', extras)
             self.assertEqual(extras['results'], results)
 
     def test_extras_logtype(self):
-        audit_log = AuditLogger()
-        extras = audit_log._get_extras(log_type='test_type')
+        extras = self.audit_log._get_extras(log_type='test_type')
         self.assertEqual(extras['type'], 'test_type')
 
-    @patch('audit_log.logger.logger')
-    def test_send_log_info(self, mocked_audit_logger):
+    @patch('audit_log.logger.AuditLogger.init_logger')
+    def test_send_log_info(self, mocked_init_logger):
+        mocked_logger = Mock()
+        mocked_init_logger.return_value = mocked_logger
+
+        # because we are mocking parts of the AuditLogger, we can not
+        # use the self.audit_logger created in setUp(), but we need to
+        # recreate it here!
+        audit_log = AuditLogger()
         extected_extra = {'audit': {
                 'http_request': None,
                 'http_response': None,
@@ -172,14 +204,10 @@ class TestAuditlogger(TestCase):
             }
         }
 
-        audit_log = AuditLogger()
         audit_log.info("message").send_log()
-        mocked_audit_logger.log.assert_called_with(
+        mocked_logger.log.assert_called_with(
             level=logging.INFO,
             msg='message',
             extra=extected_extra
         )
 
-        # with self.assertLogs(logger=AUDIT_LOGGER_NAME) as mocked_logger:
-        #     audit_log.info("message").send_log()
-        #     self.assertEqual(mocked_logger.output, expected_log_output)


### PR DESCRIPTION
By initializing the logger inside a method instead of in the top
of the file, we allow for implementations (such as the
DjangoAuditLogger) to override the log configuration.

This allows for easy overriding of the logger name, the log 
formatter, the log handler or the complete initialization method 
as a whole.